### PR TITLE
Handle URLs in model path without converting to absolute

### DIFF
--- a/src/node_manager.cpp
+++ b/src/node_manager.cpp
@@ -1610,7 +1610,12 @@ namespace kolosal
                 // Create new model config
                 ModelConfig modelConfig;
                 modelConfig.id = engineId;
-                modelConfig.path = ServerConfig::makeAbsolutePath(modelPath);  // Convert to absolute path
+                // Don't convert URLs to absolute paths
+                if (is_valid_url(modelPath)) {
+                    modelConfig.path = modelPath;
+                } else {
+                    modelConfig.path = ServerConfig::makeAbsolutePath(modelPath);  // Convert to absolute path
+                }
                 modelConfig.loadImmediately = loadImmediately;
                 modelConfig.mainGpuId = mainGpuId;
                 modelConfig.inferenceEngine = actualInferenceEngine;
@@ -1626,7 +1631,12 @@ namespace kolosal
                 {
                     if (existingModel.id == engineId)
                     {
-                        existingModel.path = ServerConfig::makeAbsolutePath(modelPath);  // Convert to absolute path
+                        // Don't convert URLs to absolute paths
+                        if (is_valid_url(modelPath)) {
+                            existingModel.path = modelPath;
+                        } else {
+                            existingModel.path = ServerConfig::makeAbsolutePath(modelPath);  // Convert to absolute path
+                        }
                         existingModel.loadImmediately = loadImmediately;
                         existingModel.mainGpuId = mainGpuId;
                         existingModel.inferenceEngine = actualInferenceEngine;

--- a/src/server_config.cpp
+++ b/src/server_config.cpp
@@ -1,5 +1,6 @@
 #include "kolosal/server_config.hpp"
 #include "kolosal/logger.hpp"
+#include "kolosal/download_utils.hpp"
 #include <yaml-cpp/yaml.h>
 #include <iostream>
 #include <fstream>
@@ -793,8 +794,15 @@ namespace kolosal
                     ModelConfig model;
                     if (modelConfig["id"])
                         model.id = modelConfig["id"].as<std::string>();
-                    if (modelConfig["path"])
-                        model.path = ServerConfig::makeAbsolutePath(modelConfig["path"].as<std::string>());
+                    if (modelConfig["path"]) {
+                        std::string pathStr = modelConfig["path"].as<std::string>();
+                        // Don't convert URLs to absolute paths
+                        if (is_valid_url(pathStr)) {
+                            model.path = pathStr;
+                        } else {
+                            model.path = ServerConfig::makeAbsolutePath(pathStr);
+                        }
+                    }
                     if (modelConfig["type"])
                         model.type = modelConfig["type"].as<std::string>();
                     // Support both new and old field names for backward compatibility


### PR DESCRIPTION
Updated logic in node_manager.cpp and server_config.cpp to avoid converting model paths to absolute paths if they are valid URLs. This ensures remote resources are referenced correctly and not misinterpreted as local file paths.